### PR TITLE
allow merging of SIGTERM handlers

### DIFF
--- a/h5pyswmr/locking.py
+++ b/h5pyswmr/locking.py
@@ -25,13 +25,10 @@ programmers should make sure that clients do not exceed lock timeouts.
 """
 
 import os
-import sys
 import time
 import contextlib
 import uuid
-import signal
 from functools import wraps
-from collections import defaultdict
 
 import redis
 
@@ -56,7 +53,7 @@ WRITELOCK_ID = 'id_reader'
 READLOCK_ID = 'id_writer'
 
 
-def reader(f, append=APPEND_SIGHANDLER):
+def reader(f):
     """
     Decorates methods reading an HDF5 file.
     """
@@ -67,7 +64,7 @@ def reader(f, append=APPEND_SIGHANDLER):
         Wraps reading functions.
         """
 
-        with handle_exit(append=append):
+        with handle_exit(append=APPEND_SIGHANDLER):
             # names of locks
             mutex3 = 'mutex3__{}'.format(self.file)
             mutex1 = 'mutex1__{}'.format(self.file)

--- a/h5pyswmr/locking.py
+++ b/h5pyswmr/locking.py
@@ -43,6 +43,7 @@ redis_conn = redis.StrictRedis(host='localhost', port=6379, db=0,
                                decode_responses=True)  # important for Python3
 
 
+APPEND_SIGHANDLER = False
 DEFAULT_TIMEOUT = 20  # seconds
 ACQ_TIMEOUT = 15
 
@@ -55,7 +56,7 @@ WRITELOCK_ID = 'id_reader'
 READLOCK_ID = 'id_writer'
 
 
-def reader(f):
+def reader(f, append=APPEND_SIGHANDLER):
     """
     Decorates methods reading an HDF5 file.
     """
@@ -66,7 +67,7 @@ def reader(f):
         Wraps reading functions.
         """
 
-        with handle_exit():
+        with handle_exit(append=append):
             # names of locks
             mutex3 = 'mutex3__{}'.format(self.file)
             mutex1 = 'mutex1__{}'.format(self.file)


### PR DESCRIPTION
I have a SIGTERM handler already defined in my application, which raises an error. It looks like your code already allows easy merging of these.

```
from h5pyswmr import locking
locking.APPEND_SIGHANDLER = True
```

(also removed a few unused imports as reported by flake8)
