### PR TITLE
fix(setup): use io.open to read long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 """
 Setup script
 """
-
+import io
 import os
 
 try:
@@ -14,7 +14,7 @@ except ImportError:
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the README file
-with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Should make h5pySWMR Python 2.7 compatible
